### PR TITLE
Add 'description' attribute to schema

### DIFF
--- a/examples/complete/README.MD
+++ b/examples/complete/README.MD
@@ -1,0 +1,9 @@
+# Example
+* `terraform init`
+* `terraform plan --var-file=wgvars.tfvars`
+* `terraform apply --var-file=wgvars.tfvars`
+
+# Expected results
+* Two peer configuration files created in the outputs directory which can then be used with `qrencode -r <FILE> -ansiutf8`
+* `terraform.tfstate` is more readable where the resource can easily be identified with description persisted for troubleshooting wireguard issues such as incorrect keys etc
+

--- a/examples/complete/outputs/mbp15.conf
+++ b/examples/complete/outputs/mbp15.conf
@@ -1,0 +1,15 @@
+# Client configuration for => MBP 15
+[Interface]
+Address = 10.100.0.3/32
+DNS = 10.100.0.1
+PrivateKey = aL9aIbl9kajJLAJuX9sWBy81E7jI7vTs3ngZoEAO5kQ=
+MTU = 1480 
+
+[Peer]
+AllowedIPs = 0.0.0.0/0
+Endpoint = myserver.amazonaws.com:41240
+PersistentKeepAlive = 25
+PublicKey = fcdAWZ/12/rGS6VRhvg6V9ISkjsEpfx/fzYUEcoOqxY=
+PresharedKey = RY3MDeBXsB3WrJycV6C+dhFKZ/prnCmKC067bgi9Z1Y=
+
+

--- a/examples/complete/outputs/sams20.conf
+++ b/examples/complete/outputs/sams20.conf
@@ -1,0 +1,15 @@
+# Client configuration for => Samsung S20
+[Interface]
+Address = 10.100.0.2/32
+DNS = 10.100.0.1
+PrivateKey = wPF7E0xHsY4Xci+fTZJTg36pLmDjxgtZk+Aduc4hUUg=
+MTU = 1480 
+
+[Peer]
+AllowedIPs = 0.0.0.0/0
+Endpoint = myserver.amazonaws.com:41240
+PersistentKeepAlive = 25
+PublicKey = fcdAWZ/12/rGS6VRhvg6V9ISkjsEpfx/fzYUEcoOqxY=
+PresharedKey = 1nN52sdLAVyrNL7SMIimr5Mn6VgvQtI49LBC/zEVC1s=
+
+

--- a/examples/complete/outputs/wg.conf
+++ b/examples/complete/outputs/wg.conf
@@ -1,0 +1,18 @@
+[Interface]
+Address = 10.100.0.1/24
+PrivateKey = iIquCC+BMaS73TYsS6CfEWYbjM9Hk2K3b3q8LL6wqX4=
+ListenPort = 41240
+
+
+# Samsung S20
+[Peer]
+PublicKey = ngjJ/S98J2AXD4PHahGKn0UtJi7ZmQY5X4n3p0eHUyg=
+PresharedKey = 1nN52sdLAVyrNL7SMIimr5Mn6VgvQtI49LBC/zEVC1s=
+AllowedIPs = 10.100.0.2/32
+
+# MBP 15
+[Peer]
+PublicKey = zeVoohx1oA76XovmvWtkl9zSwQjYSgnDVXegSM9tJgI=
+PresharedKey = RY3MDeBXsB3WrJycV6C+dhFKZ/prnCmKC067bgi9Z1Y=
+AllowedIPs = 10.100.0.3/32
+

--- a/examples/complete/templates/client.tftpl
+++ b/examples/complete/templates/client.tftpl
@@ -1,0 +1,14 @@
+# Client configuration for => ${wgPeerDescription}
+[Interface]
+Address = ${wgPeerAddress}
+DNS = ${wgPeerDnsAddress}
+PrivateKey = ${wgPeerPrivateKey}
+%{ if wgPeerMTU != "" }MTU = ${wgPeerMTU}%{ endif } 
+
+[Peer]
+AllowedIPs = ${wgPeerAllowedIps}
+Endpoint = ${wgPeerEndpoint}:${wgServerPort}
+PersistentKeepAlive = ${wgPeerKeepAlive}
+PublicKey = ${wgServerPublicKey}
+PresharedKey = ${wgPeerPresharedKey}
+

--- a/examples/complete/wgvars.tfvars
+++ b/examples/complete/wgvars.tfvars
@@ -1,0 +1,29 @@
+server_public_key  = "NOT_A_REAL_KEY"
+server_private_key = "NOT_A_REAL_KEY"
+server_ip_address  = "10.100.0.1/24"
+keep_alive         = 25
+endpoint           = "myserver.amazonaws.com"
+listen_port        = 41240
+mtu                = 1480
+dns                = ["10.100.0.1"]
+
+peers_map = [
+  {
+    indexCount    = 0
+    description   = "Samsung S20"
+    configFile    = "sams20.conf"
+    address       = ["10.100.0.2/32"]
+    allowed_ips   = ["0.0.0.0/0"]
+    preshared_key = "N/A"
+    public_key    = "N/A"
+  },
+  {
+    indexCount    = 1
+    description   = "MBP 15"
+    configFile    = "mbp15.conf"
+    address       = ["10.100.0.3/32"]
+    allowed_ips   = ["0.0.0.0/0"]
+    preshared_key = "N/A"
+    public_key    = "N/A"
+  },
+]

--- a/examples/complete/wireguard_res.tf
+++ b/examples/complete/wireguard_res.tf
@@ -1,0 +1,171 @@
+# terraform plan --var-file=wgvars.tfvars
+terraform {
+  required_providers {
+    wireguard = {
+      source  = "OJFord/wireguard"
+      version = "~> 0.2.1"
+    }
+  }
+}
+
+provider "wireguard" {
+  # Configuration options
+}
+
+#####################################
+#
+# Variables
+#
+#####################################
+variable "server_private_key" {}
+variable "server_public_key" {}
+variable "server_ip_address" {}
+variable "keep_alive" {}
+variable "endpoint" {}
+variable "listen_port" {}
+variable "mtu" {}
+variable "dns" {}
+
+variable "peers_map" {
+  type = list(object({
+    indexCount    = number
+    configFile    = string
+    description   = string
+    address       = list(string)
+    public_key    = string
+    preshared_key = string
+    allowed_ips   = list(string)
+  }))
+}
+
+#####################################
+#
+# Outputs
+#
+#####################################
+output "server_public_key" {
+  description = "Public Key"
+  value       = wireguard_asymmetric_key.server.public_key
+}
+
+output "server_private_key" {
+  description = "Private Key"
+  value       = wireguard_asymmetric_key.server.private_key
+  sensitive   = true
+}
+
+output "wireguard_server_config" {
+  value     = data.wireguard_config_document.server.conf
+  sensitive = true
+}
+
+#####################################
+#
+# Templates
+#
+#####################################
+resource "local_file" "server" {
+  filename = "outputs/wg.conf"
+  content  = <<-EOT
+  [Interface]
+  Address = ${var.server_ip_address}
+  PrivateKey = ${data.wireguard_config_document.server.private_key}
+  ListenPort = ${var.listen_port}
+
+  %{for peer in var.peers_map}
+  # ${peer.description}
+  [Peer]
+  PublicKey = ${wireguard_asymmetric_key.peer[peer.indexCount].public_key}
+  PresharedKey = ${wireguard_asymmetric_key.peer_preshared[peer.indexCount].public_key}
+  AllowedIPs = ${join(",", peer.address)}
+  %{endfor}
+  EOT
+}
+
+data "template_file" "peers_client" {
+  count    = length(var.peers_map)
+  template = file("templates/client.tftpl")
+  vars = {
+    wgPeerDescription  = var.peers_map[count.index].description
+    wgPeerAddress      = join(",", var.peers_map[count.index].address)
+    wgPeerDnsAddress   = join(",", var.dns)
+    wgPeerPrivateKey   = wireguard_asymmetric_key.peer[count.index].private_key
+    wgPeerAllowedIps   = join(",", var.peers_map[count.index].allowed_ips)
+    wgPeerEndpoint     = var.endpoint
+    wgServerPort       = var.listen_port
+    wgServerPublicKey  = wireguard_asymmetric_key.server.public_key
+    wgPeerPresharedKey = wireguard_asymmetric_key.peer_preshared[count.index].public_key
+    wgPeerKeepAlive    = var.keep_alive
+    wgPeerMTU          = var.mtu
+  }
+}
+
+
+#####################################
+#
+# null_resource
+#
+#####################################
+resource "null_resource" "client_conf" {
+  count = length(var.peers_map)
+
+  triggers = {
+    template = data.template_file.peers_client[count.index].rendered
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${data.template_file.peers_client[count.index].rendered}\" > outputs/${var.peers_map[count.index].configFile}"
+  }
+}
+
+#####################################
+#
+# Wireguard Peers / Preshared
+#
+#####################################
+resource "wireguard_asymmetric_key" "peer" {
+  count       = length(var.peers_map)
+  description = "Peer's public / private key(s) for ${var.peers_map[count.index].description}"
+}
+
+resource "wireguard_asymmetric_key" "peer_preshared" {
+  count       = length(var.peers_map)
+  description = "Peer's preshared public key(s) for ${var.peers_map[count.index].description}"
+}
+
+#####################################
+#
+# Wireguard Server
+#
+#####################################
+resource "wireguard_asymmetric_key" "server" {
+  description = "My Wireguard Server Public/Private Keys"
+}
+
+#####################################
+#
+# Wireguard Provisioning
+#
+#####################################
+data "wireguard_config_document" "server" {
+  private_key = wireguard_asymmetric_key.server.private_key
+
+  listen_port = var.listen_port
+  mtu         = var.mtu
+  dns         = var.dns
+  description = "My Wireguard Server"
+
+  dynamic "peer" {
+    for_each = var.peers_map
+    content {
+
+      public_key           = wireguard_asymmetric_key.peer[peer.value.indexCount].public_key
+      preshared_key        = wireguard_asymmetric_key.peer_preshared[peer.value.indexCount].public_key
+      allowed_ips          = peer.value.allowed_ips
+      endpoint             = "${var.endpoint}:${var.listen_port}"
+      persistent_keepalive = var.keep_alive
+      description          = "Peer # ${peer.value.indexCount} is => ${peer.value.description}"
+    }
+  }
+}
+

--- a/provider/resource_wireguard_asymmetric_key.go
+++ b/provider/resource_wireguard_asymmetric_key.go
@@ -34,6 +34,12 @@ func resourceWireguardAsymmetricKey() *schema.Resource {
 				Computed:    true,
 				Type:        schema.TypeString,
 			},
+			"description": {
+				Description: "A string to represent the resource holder of public/private key",
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
 		},
 	}
 }
@@ -48,6 +54,11 @@ func resourceWireguardAsymmetricKeyCreate(d *schema.ResourceData, m interface{})
 		d.Set("private_key", key.String())
 	} else {
 		key, err = wgtypes.ParseKey(private_key.(string))
+	}
+
+	description := d.Get("description")
+	if description != "" {
+		d.Set("description", description.(string))
 	}
 
 	if err != nil {

--- a/provider/resource_wireguard_preshared_key.go
+++ b/provider/resource_wireguard_preshared_key.go
@@ -22,6 +22,12 @@ func resourceWireguardPresharedKey() *schema.Resource {
 				Sensitive:   true,
 				Type:        schema.TypeString,
 			},
+			"description": {
+				Description: "A string to represent the resource holder of preshared keys",
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
 		},
 	}
 }
@@ -32,6 +38,10 @@ func resourceWireguardPresharedKeyCreate(d *schema.ResourceData, m interface{}) 
 
 	key, err = wgtypes.GenerateKey()
 	err = d.Set("key", key.String())
+	description := d.Get("description")
+	if description != "" {
+		d.Set("description", description.(string))
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Included an additional attribute to the terraform schema to include `description`, this would go some way to make things easier in inspecting the `terraform.tfstate` file to see which resource is which.

In addition to the above, have enclosed an example of using **Terraform v1.1.7** to generate output files to make use of `qrencode` in a easier manner.