### PR TITLE
Add optional description field for peers

### DIFF
--- a/docs/data-sources/config_document.md
+++ b/docs/data-sources/config_document.md
@@ -81,6 +81,7 @@ Required:
 Optional:
 
 - `allowed_ips` (List of String) IPs (or CIDR) allowed for traffic to/from this peer.
+- `description` (String) A description for this peer.
 - `endpoint` (String) An endpoint IP:port or hostname:port at which this peer can be reached initially.
 - `persistent_keepalive` (Number) Period in seconds (or "off") after which to ping the peer to keep a stateful firewall or NAT mapping valid.
 - `preshared_key` (String) A base64 preshared key from this peer.

--- a/provider/data_source_wireguard_config_document.go
+++ b/provider/data_source_wireguard_config_document.go
@@ -136,6 +136,11 @@ func dataSourceWireguardConfigDocument() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 						},
+						"description": {
+							Description: "A description for this peer.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 					},
 				},
 			},
@@ -194,6 +199,9 @@ PostDown = {{ . }}
 {{- range .Peers }}
 
 [Peer]
+{{- if .Description }}
+# {{ .Description }}
+{{- end }}
 PublicKey = {{ .PublicKey }}
 
 {{- if .PresharedKey }}
@@ -219,6 +227,7 @@ var wgTemplate = template.Must(template.New("wg").Parse(wgTemplateStr))
 
 type WgPeerConfig struct {
 	PublicKey           string
+	Description         *string
 	PresharedKey        *string
 	AllowedIPs          []string
 	Endpoint            *string
@@ -354,6 +363,11 @@ func dataSourceWireguardConfigDocumentRead(d *schema.ResourceData, m interface{}
 			if v := peer["persistent_keepalive"]; v != 0 {
 				ka := v.(int)
 				peerCfg.PersistentKeepalive = &ka
+			}
+
+			if v := peer["description"]; v != "" {
+				desc := v.(string)
+				peerCfg.Description = &desc
 			}
 
 			cfg.Peers = append(cfg.Peers, peerCfg)

--- a/provider/data_source_wireguard_config_document.go
+++ b/provider/data_source_wireguard_config_document.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"strings"
 	"text/template"
 )
 
@@ -200,7 +201,9 @@ PostDown = {{ . }}
 
 [Peer]
 {{- if .Description }}
-# {{ .Description }}
+{{- range .Description }}
+# {{ . }}
+{{- end }}
 {{- end }}
 PublicKey = {{ .PublicKey }}
 
@@ -227,7 +230,7 @@ var wgTemplate = template.Must(template.New("wg").Parse(wgTemplateStr))
 
 type WgPeerConfig struct {
 	PublicKey           string
-	Description         *string
+	Description         []string
 	PresharedKey        *string
 	AllowedIPs          []string
 	Endpoint            *string
@@ -366,8 +369,8 @@ func dataSourceWireguardConfigDocumentRead(d *schema.ResourceData, m interface{}
 			}
 
 			if v := peer["description"]; v != "" {
-				desc := v.(string)
-				peerCfg.Description = &desc
+				desc := strings.Split(v.(string), "\n")
+				peerCfg.Description = desc
 			}
 
 			cfg.Peers = append(cfg.Peers, peerCfg)


### PR DESCRIPTION
The description, if provided, will be added as a comment right under `[Peer]` in the config document. This can help identify at a glance all the peers when looking at the config once it is stored on the server.