### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,9 @@
 name: Check
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/OJFord/terraform-provider-wireguard/security/code-scanning/4](https://github.com/OJFord/terraform-provider-wireguard/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will apply to all jobs in the workflow unless they have their own `permissions` block. Based on the actions performed in the workflow, the minimal required permissions are `contents: read` for accessing the repository's contents and `pull-requests: write` for any pull request-related operations. Each job will inherit these permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
