### PR TITLE
Permission workflow explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OJFord/terraform-provider-wireguard/security/code-scanning/1](https://github.com/OJFord/terraform-provider-wireguard/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it likely needs `contents: read` for accessing repository files and `packages: write` for publishing releases. If additional permissions are required (e.g., `issues: write` or `pull-requests: write`), they should be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `goreleaser` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
